### PR TITLE
UnionTypes.scala: Fix crash with recent Dotty

### DIFF
--- a/src/main/scala/UnionTypes.scala
+++ b/src/main/scala/UnionTypes.scala
@@ -36,8 +36,8 @@ object UnionTypes {
     // calling `either` function with union typed value.
     println(either(divisionResultFailure))
 
-    val list: Cons | Empty = Cons(1, Cons(2, Cons(3, Empty())))
-    val emptyList: Empty | Cons = Empty()
+    val list: Cons[Int] | Empty = Cons(1, Cons(2, Cons(3, Empty())))
+    val emptyList: Empty | Cons[Any] = Empty()
     println(list)
     println(emptyList)
 


### PR DESCRIPTION
Types in union need to be fully applied, the previous code was wrong but
happened to work before https://github.com/lampepfl/dotty/pull/3061. See
https://github.com/lampepfl/dotty/issues/3161.