### PR TITLE
Update sbt-dotty version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You will need to make the following adjustments to your build:
 
 ### project/plugins.sbt
 ```scala
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.5")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.6")
 ```
 
 ### project/build.properties


### PR DESCRIPTION
Update from `project/plugins.sbt`. Not 100% sure if people should use the same version as this example project, but it does seem a reasonable assumption.