### PR TITLE
Release Dotty 0.13.0-RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Any version number that starts with `0.` is automatically recognized as Dotty by
 the `sbt-dotty` plugin, you don't need to set up anything:
 
 ```scala
-scalaVersion := "0.12.0-RC1"
+scalaVersion := "0.13.0-RC1"
 ```
 
 #### Nightly builds
 If the latest release of Dotty is missing a bugfix or feature you need, you may
 wish to use a nightly build. Look at the bottom of
-https://repo1.maven.org/maven2/ch/epfl/lamp/dotty_0.13/ to find the version
+https://repo1.maven.org/maven2/ch/epfl/lamp/dotty_0.14/ to find the version
 number for the latest nightly build. Alternatively, you can set `scalaVersion :=
 dottyLatestNightlyBuild.get` to always use the latest nightly build of dotty.
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ You will need to make the following adjustments to your build:
 
 ### project/plugins.sbt
 ```scala
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.2.6")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.0")
 ```
 
 ### project/build.properties
 ```scala
-sbt.version=1.2.3
+sbt.version=1.2.7
 ```
 
 Older versions of sbt are not supported.

--- a/build.sbt
+++ b/build.sbt
@@ -5,5 +5,5 @@ lazy val root = project
     description := "Example sbt project that compiles using Dotty",
     version := "0.1.0",
 
-    scalaVersion := "0.12.0-RC1"
+    scalaVersion := "0.13.0-RC1"
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.2.6")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.0")

--- a/src/main/scala/AutoParamTupling.scala
+++ b/src/main/scala/AutoParamTupling.scala
@@ -1,6 +1,6 @@
 
 /**
-  * Automatic Tupling of Function Params: http://dotty.epfl.ch/docs/reference/auto-parameter-tupling.html
+  * Automatic Tupling of Function Params: https://dotty.epfl.ch/docs/reference/other-new-features/auto-parameter-tupling.html
   */
 object AutoParamTupling {
 
@@ -8,7 +8,7 @@ object AutoParamTupling {
 
     /**
       * In order to get thread safety, you need to put @volatile before lazy vals.
-      * http://dotty.epfl.ch/docs/reference/changed/lazy-vals.html
+      * https://dotty.epfl.ch/docs/reference/changed-features/lazy-vals.html
       */
     @volatile lazy val xs: List[String] = List("d", "o", "t", "t", "y")
 

--- a/src/main/scala/ContextQueries.scala
+++ b/src/main/scala/ContextQueries.scala
@@ -3,27 +3,25 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 /**
-  * Implicit Function Types:
-  * - http://dotty.epfl.ch/docs/reference/implicit-function-types.html,
+  * Context Queries:
+  * - http://dotty.epfl.ch/docs/reference/contextual/query-types.html,
   * - https://www.scala-lang.org/blog/2016/12/07/implicit-function-types.html
   */
-object ImplicitFunctions {
+object ContextQueries /* Formerly known as Implicit Function Types */ {
 
   object context {
     // type alias Contextual
-    type Contextual[T] = implicit ExecutionContext => T
+    type Contextual[T] = given ExecutionContext => T
 
     // sum is expanded to sum(x, y)(ctx)
     def asyncSum(x: Int, y: Int): Contextual[Future[Int]] = Future(x + y)
 
-    def asyncMult(x: Int, y: Int) = { implicit ctx: ExecutionContext =>
-      Future(x * y)
-    }
+    def asyncMult(x: Int, y: Int) given (ctx: ExecutionContext) = Future(x * y)
   }
 
   object parse {
 
-    type Parseable[T] = implicit ImplicitParams.StringParser[T] => Try[T]
+    type Parseable[T] = given ImplicitParams.StringParser[T] => Try[T]
 
     def sumStrings(x: String, y: String): Parseable[Int] = {
       val parser = implicitly[ImplicitParams.StringParser[Int]]

--- a/src/main/scala/ContextQueries.scala
+++ b/src/main/scala/ContextQueries.scala
@@ -21,10 +21,10 @@ object ContextQueries /* Formerly known as Implicit Function Types */ {
 
   object parse {
 
-    type Parseable[T] = given ImplicitParams.StringParser[T] => Try[T]
+    type Parseable[T] = given ImpliedInstances.StringParser[T] => Try[T]
 
     def sumStrings(x: String, y: String): Parseable[Int] = {
-      val parser = implicitly[ImplicitParams.StringParser[Int]]
+      val parser = implicitly[ImpliedInstances.StringParser[Int]]
       val tryA = parser.parse(x)
       val tryB = parser.parse(y)
 

--- a/src/main/scala/Conversion.scala
+++ b/src/main/scala/Conversion.scala
@@ -1,20 +1,20 @@
 import scala.language.implicitConversions
 
 /**
-  * Implicit Conversions: http://dotty.epfl.ch/docs/reference/changed-features/implicit-conversions.html
+  *  Conversions: http://dotty.epfl.ch/docs/reference/contextual/conversions.html
   */
-object ImplicitConversion {
+object Conversion {
 
   case class IntWrapper(a: Int) extends AnyVal
   case class DoubleWrapper(b: Double) extends AnyVal
 
-  def convert[T, U](x: T)(implicit converter: ImplicitConverter[T, U]): U = converter(x)
+  def convert[T, U](x: T) given (converter: Conversion[T, U]): U = converter(x)
 
-  implicit val IntWrapperToDoubleWrapper: ImplicitConverter[IntWrapper, DoubleWrapper] = new ImplicitConverter[IntWrapper, DoubleWrapper] {
+  implied IntWrapperToDoubleWrapper for Conversion[IntWrapper, DoubleWrapper] = new Conversion[IntWrapper, DoubleWrapper] {
     override def apply(i: IntWrapper): DoubleWrapper = new DoubleWrapper(i.a.toDouble)
   }
 
-  def useConversion(implicit f: ImplicitConverter[IntWrapper, DoubleWrapper]) = {
+  def useConversion given (f: Conversion[IntWrapper, DoubleWrapper]) = {
     val y: IntWrapper = new IntWrapper(4)
     val x: DoubleWrapper = y
     x

--- a/src/main/scala/EnumTypes.scala
+++ b/src/main/scala/EnumTypes.scala
@@ -1,5 +1,5 @@
 /**
-  * Enum Types: http://dotty.epfl.ch/docs/reference/adts.html
+  * Enum Types: http://dotty.epfl.ch/docs/reference/enums/adts.html
   */
 object EnumTypes {
 

--- a/src/main/scala/IntersectionTypes.scala
+++ b/src/main/scala/IntersectionTypes.scala
@@ -1,5 +1,5 @@
 /**
-  * Intersection Types: http://dotty.epfl.ch/docs/reference/intersection-types.html
+  * Intersection Types: https://dotty.epfl.ch/docs/reference/new-types/intersection-types.html
   */
 object IntersectionTypes {
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -7,11 +7,11 @@ object Main {
 
     runExample("Enum Types")(EnumTypes.test)
 
-    runExample("Implicit Functions")(ImplicitFunctions.test)
+    runExample("Context Queries")(ContextQueries.test)
 
     runExample("Implicit Params")(ImplicitParams.test)
 
-    runExample("Implicit Conversion")(ImplicitConversion.test)
+    runExample("Conversion")(Conversion.test)
 
     runExample("Union Types")(UnionTypes.test)
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,7 +9,7 @@ object Main {
 
     runExample("Context Queries")(ContextQueries.test)
 
-    runExample("Implicit Params")(ImplicitParams.test)
+    runExample("Implied Instances")(ImpliedInstances.test)
 
     runExample("Conversion")(Conversion.test)
 

--- a/src/main/scala/MultiversalEquality.scala
+++ b/src/main/scala/MultiversalEquality.scala
@@ -1,8 +1,8 @@
 import scala.language.strictEquality
 
 /**
-  * Multiversal Equality: http://dotty.epfl.ch/docs/reference/multiversal-equality.html
-  * scala.Eq definition: https://github.com/lampepfl/dotty/blob/master/library/src/scala/Eq.scala
+  * Multiversal Equality: https://dotty.epfl.ch/docs/reference/contextual/multiversal-equality.html
+  * scala.Eq definition: https://github.com/lampepfl/dotty/blob/master/library/src/scala/Eql.scala
   */
 object MultiversalEquality {
 
@@ -10,7 +10,7 @@ object MultiversalEquality {
 
     // Values of types Int and String cannot be compared with == or !=,
     // unless we add a custom implicit like:
-    implicit def eqIntString: Eq[Int, String] = Eq
+    implicit def eqIntString: Eql[Int, String] = Eql.derived
     println(3 == "3")
 
     // By default, all numbers are comparable, because of;
@@ -29,8 +29,8 @@ object MultiversalEquality {
 
     // scala.language.strictEquality is enabled, therefore we need some extra implicits
     // to compare instances of A and B.
-    implicit def eqAB: Eq[A, B] = Eq
-    implicit def eqBA: Eq[B, A] = Eq
+    implicit def eqAB: Eql[A, B] = Eql.derived
+    implicit def eqBA: Eql[B, A] = Eql.derived
 
     println(a != b)
     println(b == a)

--- a/src/main/scala/MultiversalEquality.scala
+++ b/src/main/scala/MultiversalEquality.scala
@@ -9,16 +9,16 @@ object MultiversalEquality {
   def test: Unit = {
 
     // Values of types Int and String cannot be compared with == or !=,
-    // unless we add a custom implicit like:
-    implicit def eqIntString: Eql[Int, String] = Eql.derived
+    // unless we add the derived implied instance like:
+    implied for Eql[Int, String] = Eql.derived
     println(3 == "3")
 
     // By default, all numbers are comparable, because of;
-    // implicit def eqNumber : Eq[Number, Number] = Eq
+    // implicit def eqlNumber: Eql[Number, Number] = derived
     println(3 == 5.1)
 
     // By default, all Sequences are comparable, because of;
-    // implicit def eqSeq[T, U](implicit eq: Eq[T, U]): Eq[Seq[T], Seq[U]] = Eq
+    // implicit def eqlSeq[T, U](implicit eq: Eql[T, U]): Eql[GenSeq[T], GenSeq[U]] = derived
     println(List(1, 2) == Vector(1, 2))
 
     class A(a: Int)
@@ -27,10 +27,10 @@ object MultiversalEquality {
     val a = new A(4)
     val b = new B(4)
 
-    // scala.language.strictEquality is enabled, therefore we need some extra implicits
+    // scala.language.strictEquality is enabled, therefore we need some extra implied instances
     // to compare instances of A and B.
-    implicit def eqAB: Eql[A, B] = Eql.derived
-    implicit def eqBA: Eql[B, A] = Eql.derived
+    implied for Eql[A, B] = Eql.derived
+    implied for Eql[B, A] = Eql.derived
 
     println(a != b)
     println(b == a)

--- a/src/main/scala/NamedTypeArguments.scala
+++ b/src/main/scala/NamedTypeArguments.scala
@@ -1,6 +1,6 @@
 
 /**
-  * Named Type Arguments: http://dotty.epfl.ch/docs/reference/named-typeargs.html
+  * Named Type Arguments: https://dotty.epfl.ch/docs/reference/other-new-features/named-typeargs.html
   */
 object NamedTypeArguments {
 

--- a/src/main/scala/PatternMatching.scala
+++ b/src/main/scala/PatternMatching.scala
@@ -1,6 +1,6 @@
 
 /**
-  * Pattern Matching: http://dotty.epfl.ch/docs/reference/changed/pattern-matching.html
+  * Pattern Matching: https://dotty.epfl.ch/docs/reference/changed-features/pattern-matching.html
   */
 object PatternMatching {
 

--- a/src/main/scala/StructuralTypes.scala
+++ b/src/main/scala/StructuralTypes.scala
@@ -1,6 +1,6 @@
 
 /**
-  * Structural Types: http://dotty.epfl.ch/docs/reference/changed/structural-types.html
+  * Structural Types: https://dotty.epfl.ch/docs/reference/changed-features/structural-types.html
   */
 object StructuralTypes {
 

--- a/src/main/scala/TraitParams.scala
+++ b/src/main/scala/TraitParams.scala
@@ -1,5 +1,5 @@
 /**
-  * Trait Parameters: http://dotty.epfl.ch/docs/reference/trait-parameters.html
+  * Trait Parameters: https://dotty.epfl.ch/docs/reference/other-new-features/trait-parameters.html
   */
 object TraitParams {
 

--- a/src/main/scala/TypeLambdas.scala
+++ b/src/main/scala/TypeLambdas.scala
@@ -1,5 +1,5 @@
 /**
-  * Type Lambdas: http://dotty.epfl.ch/docs/reference/type-lambdas.html
+  * Type Lambdas: https://dotty.epfl.ch/docs/reference/new-types/type-lambdas.html
   */
 object TypeLambdas {
 

--- a/src/main/scala/UnionTypes.scala
+++ b/src/main/scala/UnionTypes.scala
@@ -1,5 +1,5 @@
 /**
-  * Union Types: http://dotty.epfl.ch/docs/reference/union-types.html
+  * Union Types: https://dotty.epfl.ch/docs/reference/new-types/union-types.html
   */
 object UnionTypes {
 


### PR DESCRIPTION
This PR updates the dotty version, the sbt-dotty version and the SBT version. It applies the changes for implicits. 

Before applying the same changes to #26 for mill can you take a look @smarter? Do we keep `ImplicitParams.scala` as is or should we upgrade it too?