### PR TITLE
Travis: replace broken oraclejdk8 with openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   - sbt run


### PR DESCRIPTION
oraclejdk8 doesn't work any more (for licensing reasons?), but openjdk8 does.
I confirmed this behavior on
https://travis-ci.org/Blaisorblade/scala19_gadt_code/builds/542859151 vs
https://travis-ci.org/Blaisorblade/scala19_gadt_code/builds/542859522.

This PR gets an error, but that's a genuine one (on nightly), due to the syntax changes for type lambdas.