### PR TITLE
Update link to manually determine latest nightly build from 0.18 to 0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ scalaVersion := "0.20.0-RC1"
 #### Nightly builds
 If the latest release of Dotty is missing a bugfix or feature you need, you may
 wish to use a nightly build. Look at the bottom of
-https://repo1.maven.org/maven2/ch/epfl/lamp/dotty_0.18/ to find the version
+https://repo1.maven.org/maven2/ch/epfl/lamp/dotty_0.21/ to find the version
 number for the latest nightly build. Alternatively, you can set `scalaVersion :=
 dottyLatestNightlyBuild.get` to always use the latest nightly build of dotty.
 


### PR DESCRIPTION
Using `dottyLatestNightlyBuild.get` pulls `ch.epfl.lamp#dotty-library_0.21;0.21.0-bin-20191211-731ee3c-NIGHTLY!dotty-library_0.21.jar` (as of around 12:20 PM PST), so the link in the readme to visually confirm the latest nightly build needs updated so they are consistent.